### PR TITLE
Prevents function call ambiguity with 32 bit systems

### DIFF
--- a/IridiumSBD.cpp
+++ b/IridiumSBD.cpp
@@ -256,7 +256,7 @@ int IridiumSBD::internalSendReceiveSBD(const char *txTxtMessage, const uint8_t *
       }
 
       console(F("["));
-      console(txDataSize);
+      console((uint16_t)txDataSize);
       console(F(" bytes]"));
 
       dbg(F("Checksum:"));


### PR DESCRIPTION
Such as the teensy 3.1 or other arduino compatable systems where size_t is 32 bit rather than 16 bit.
