### PR TITLE
Improve ARM power consumption with WAIT

### DIFF
--- a/src/IridiumSBD.cpp
+++ b/src/IridiumSBD.cpp
@@ -552,6 +552,9 @@ bool IridiumSBD::waitForATResponse(char *response, int responseSize, const char 
    consoleprint(F("<< "));
    for (unsigned long start=millis(); millis() - start < 1000UL * atTimeout;)
    {
+      #if defined(__arm__)
+	   asm volatile ("wfi"); //Pause loop until interupt
+	   #endif
       if (cancelled())
          return false;
 

--- a/src/IridiumSBD.cpp
+++ b/src/IridiumSBD.cpp
@@ -553,8 +553,8 @@ bool IridiumSBD::waitForATResponse(char *response, int responseSize, const char 
    for (unsigned long start=millis(); millis() - start < 1000UL * atTimeout;)
    {
       #if defined(__arm__)
-	   asm volatile ("wfi"); //Pause loop until interupt
-	   #endif
+      asm volatile ("wfi"); //Pause loop until interupt
+      #endif
       if (cancelled())
          return false;
 

--- a/src/IridiumSBD.cpp
+++ b/src/IridiumSBD.cpp
@@ -564,9 +564,6 @@ bool IridiumSBD::waitForATResponse(char *response, int responseSize, const char 
    consoleprint(F("<< "));
    for (unsigned long start=millis(); millis() - start < 1000UL * atTimeout;)
    {
-      #if defined(__arm__)
-      asm volatile ("wfi"); //Pause loop until interupt
-      #endif
       if (cancelled())
          return false;
 

--- a/src/IridiumSBD.cpp
+++ b/src/IridiumSBD.cpp
@@ -237,6 +237,18 @@ int IridiumSBD::getFirmwareVersion(char *version, size_t bufferSize)
    return ISBD_SUCCESS;
 }
 
+int IridiumSBD::getIMEI(char *IMEI, size_t bufferSize)
+{
+   if (bufferSize < 8)
+      return ISBD_RX_OVERFLOW;
+
+   send(F("AT+CGSN\r"));
+   if (!waitForATResponse(IMEI, bufferSize, "\n"))
+      return cancelled() ? ISBD_CANCELLED : ISBD_PROTOCOL_ERROR;
+
+   return ISBD_SUCCESS;
+}
+
 /*
 Private interface
 */

--- a/src/IridiumSBD.h
+++ b/src/IridiumSBD.h
@@ -64,6 +64,7 @@ public:
    int getSignalQuality(int &quality);
    int getSystemTime(struct tm &tm);
    int getFirmwareVersion(char *version, size_t bufferSize);
+   int getIMEI(char *IMEI, size_t bufferSize);
    int getWaitingMessageCount();
    bool isAsleep();
    bool hasRingAsserted();


### PR DESCRIPTION
Added wait for interrupt within the waitForATResponse loop.
Drastically improve power consumption while waiting for response. 

Tested on Teensy LC. 
Should work on all ARM processors with UART buffers.

SoftwareSerial might have issue. Untested since LC doesn't support it. 